### PR TITLE
Enable this mediator to do verification only

### DIFF
--- a/config/mediator.json
+++ b/config/mediator.json
@@ -1,6 +1,6 @@
 {
   "urn": "urn:uuid:70508e92-3637-4344-9a47-d46b9b373fb4",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "name": "adx-csd-mapper",
   "description": "Maps orgUnits in an ADX message to an alternate ID looked up in a CSD InfoManager",
   "defaultChannelConfig": [],
@@ -53,8 +53,21 @@
           "param": "path",
           "displayName": "Path",
           "type": "string"
+        },
+        {
+          "param": "directory",
+          "displayName": "Search directory",
+          "description": "The directory to search",
+          "type": "option",
+          "values": ["facility", "provider", "organization"]
         }
       ]
+    },
+    {
+      "param": "verifyOnly",
+      "displayName": "Verify Only",
+      "description": "If true, this mediator will only verify that the IDs in the ADX message exist in the InfoManager. It will not do any transformation of the ADX message.",
+      "type": "bool"
     }
   ],
   "config": {
@@ -66,6 +79,7 @@
       "path":"/CSD/csr/datim-small/careServicesRequest/urn:ihe:iti:csd:2014:stored-function:facility-search",
       "port":8984,
       "host":"localhost"
-    }
+    },
+    "verifyOnly": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "adx-csd-mapper",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Maps orgUnits in an ADX message to an alternate ID looked up in a CSD InfoManager",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "tap --cov -t 10 tests.js",
-    "view-cov": "tap --cov -t 10 --coverage-report=html tests.js"
+    "test": "tap --cov -t 10 --reporter=spec tests.js",
+    "view-cov": "tap --cov -t 10 --reporter=spec --coverage-report=lcov tests.js"
   },
   "bin": {
     "adx-csd-mapper": "index.js"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "tap --cov -t 10 --reporter=spec tests.js",
-    "view-cov": "tap --cov -t 10 --reporter=spec --coverage-report=lcov tests.js"
+    "test": "tap --cov --reporter=spec tests.js",
+    "view-cov": "tap --cov --reporter=spec --coverage-report=lcov tests.js"
   },
   "bin": {
     "adx-csd-mapper": "index.js"

--- a/test-dhis-server.js
+++ b/test-dhis-server.js
@@ -5,6 +5,7 @@ const http = require('http');
 
 const sucessfulResponse = 'CORRECT CODES USED';
 const failedResponse = 'INCORRECT CODES USED';
+const failedResponse2 = 'ORIGINAL CODES USED';
 
 const server = http.createServer(function (req, res) {
   let body = '';
@@ -17,6 +18,9 @@ const server = http.createServer(function (req, res) {
     if (body.indexOf('orgUnit="123"') > 0 && body.indexOf('orgUnit="456"') > 0) {
       res.writeHead(200);
       res.end(sucessfulResponse);
+    } else if (body.indexOf('orgUnit="p.ao.pepfar.3"') > 0 && body.indexOf('orgUnit="p.ao.pepfar.44"') > 0) {
+      res.writeHead(200);
+      res.end(failedResponse2);
     } else {
       res.writeHead(400);
       res.end(failedResponse);

--- a/tests.js
+++ b/tests.js
@@ -238,7 +238,7 @@ tap.test('Integration test - success case, spawned as a mediator process', funct
         });
       });
       req.end(fs.readFileSync('pulled_from_node.xml'));
-    }, 1000);
+    }, 1500);
   }, 1000);
 });
 

--- a/tests.js
+++ b/tests.js
@@ -11,6 +11,7 @@ const extractOrgUnitIds = index.__get__('extractOrgUnitIds');
 const fetchFacility = index.__get__('fetchFacility');
 const fetchMap = index.__get__('fetchMap');
 const replaceMappedIds = index.__get__('replaceMappedIds');
+const verifyIDs = index.__get__('verifyIDs');
 
 let config = index.__get__('config');
 config.infoman = {
@@ -141,6 +142,54 @@ tap.test('.replaceMappedIds', function (t) {
   t.end();
 });
 
+tap.test('.verifyIDs - should resolve on valid IDs', function (t) {
+  var csdServer = spawnCsdServer();
+  setTimeout(function () {
+    const promise = verifyIDs(['p.ao.pepfar.44', 'p.ao.pepfar.3']);
+    promise.then(function () {
+      csdServer.kill();
+      t.pass('promise resolved');
+      t.end();
+    });
+  }, 500);
+});
+
+tap.test('.verifyIDs - should reject on invalid IDs', function (t) {
+  var csdServer = spawnCsdServer();
+  setTimeout(function () {
+    const promise = verifyIDs(['p.ao.pepfar.44', 'wat']);
+    promise.then(function () {}, function (err) {
+      csdServer.kill();
+      t.equal(err.statusCode, 400);
+      t.end();
+    });
+  }, 500);
+});
+
+tap.test('.verifyIDs - should reject when cannot fetchFacility', function (t) {
+  const undo = index.__set__('fetchFacility', function (orgUnitId, callback) {
+    callback(new Error('Im a failure! :('));
+  });
+  const promise = verifyIDs(['p.ao.pepfar.3', 'p.ao.pepfar.44']);
+  promise.then(function () {}, function (err) {
+    undo();
+    t.equal(err.statusCode, 500);
+    t.end();
+  });
+});
+
+tap.test('.verifyIDs - should reject when bad xml is recieved', function (t) {
+  var csdServer = spawnCsdServer();
+  setTimeout(function () {
+    const promise = verifyIDs(['p.ao.pepfar.44', 'bad-xml']);
+    promise.then(function () {}, function (err) {
+      csdServer.kill();
+      t.equal(err.statusCode, 500);
+      t.end();
+    });
+  }, 500);
+});
+
 tap.test('Integration test - success case', function (t) {
   var csdServer = spawnCsdServer();
   var dhisServer = spawnDhisServer();
@@ -258,4 +307,65 @@ tap.test('Integration test - failure case, spawned as a mediator process but can
       call++;
     }
   });
+});
+
+tap.test('Integration test - verify only success case', function (t) {
+  var csdServer = spawnCsdServer();
+  var dhisServer = spawnDhisServer();
+  setTimeout(function () {
+    require('./config/config').register = false;
+    require('./config/mediator').config.verifyOnly = true;
+    index.start((server) => {
+      let options = {
+        host: 'localhost',
+        port: 8533,
+        method: 'POST'
+      };
+      const req = http.request(options, function (res) {
+        res.on('data', function (chunk) {
+          t.equals(chunk.toString(), 'ORIGINAL CODES USED');
+          csdServer.kill();
+          dhisServer.kill();
+          server.close();
+          t.end();
+        });
+      });
+      req.end(fs.readFileSync('pulled_from_node.xml'));
+    });
+  }, 500);
+});
+
+tap.test('Integration test - verify only failure case, verifyIDs fails', function (t) {
+  const undo = index.__set__('verifyIDs', function () {
+    return new Promise(function (resolve, reject) {
+      const err = new Error('Im a (verify) failure! :(');
+      err.statusCode = 500;
+      reject(err);
+    });
+  });
+  var csdServer = spawnCsdServer();
+  var dhisServer = spawnDhisServer();
+  setTimeout(function () {
+    require('./config/config').register = false;
+    require('./config/mediator').config.verifyOnly = true;
+    index.start((server) => {
+      let options = {
+        host: 'localhost',
+        port: 8533,
+        method: 'POST'
+      };
+      const req = http.request(options, function (res) {
+        res.on('data', function (chunk) {
+          t.equals(chunk.toString(), 'Im a (verify) failure! :(');
+          t.equals(res.statusCode, 500);
+          undo();
+          csdServer.kill();
+          dhisServer.kill();
+          server.close();
+          t.end();
+        });
+      });
+      req.end(fs.readFileSync('pulled_from_node.xml'));
+    });
+  }, 500);
 });


### PR DESCRIPTION
Via a mediator config option the user may specify whether the mediator
will transform requests by replacing IDs or if it will only verify IDs
used in the message without doing any transformation.
